### PR TITLE
Add trace_call

### DIFF
--- a/src/containers/codeSampleContainer.js
+++ b/src/containers/codeSampleContainer.js
@@ -5,7 +5,7 @@ import { useParams } from '@reach/router';
 import { getCodeSampleFriendlyArguments } from '../helpers/contracts';
 
 const TRACE_CALL = 'trace_call';
-const TRACE_ARGS_OFFSET = 2;
+const TRACE_ARGS_OFFSET = 4;
 
 const CodeSampleContainer = () => {
   const { codeSampleVisible, toggleSampleCode, abi } = useContext(AppContext);

--- a/src/containers/codeSampleContainer.js
+++ b/src/containers/codeSampleContainer.js
@@ -4,6 +4,9 @@ import { AppContext } from '../context';
 import { useParams } from '@reach/router';
 import { getCodeSampleFriendlyArguments } from '../helpers/contracts';
 
+const TRACE_CALL = 'trace_call';
+const TRACE_ARGS_OFFSET = 2;
+
 const CodeSampleContainer = () => {
   const { codeSampleVisible, toggleSampleCode, abi } = useContext(AppContext);
   const params = useParams();
@@ -18,11 +21,13 @@ const CodeSampleContainer = () => {
     toggleSampleCode();
   };
 
+  const argOffset = currentMethod === TRACE_CALL ? TRACE_ARGS_OFFSET : 0;
+
   return (
     <CodeSample
       url={atob(web3URL)}
       web3Lib={web3Lib}
-      args={getCodeSampleFriendlyArguments(argumentList, abi)}
+      args={getCodeSampleFriendlyArguments(argumentList, abi, argOffset)}
       currentMethod={currentMethod}
       hideCodeSample={hideCodeSample}
       visible={codeSampleVisible}

--- a/src/containers/methodCallContainer.js
+++ b/src/containers/methodCallContainer.js
@@ -12,7 +12,8 @@ import {
 } from '../helpers/contracts';
 import { navigate, useParams } from '@reach/router';
 
-const CONTRACT_FUNCTION_METHOD = 'eth_call';
+const ETH_CALL = 'eth_call';
+const TRACE_CALL = 'trace_call';
 
 const MethodCallContainer = () => {
   const params = useParams();
@@ -36,6 +37,9 @@ const MethodCallContainer = () => {
   const [formInputs, setFormInputs] = useState([]);
   const [argumentList, setArgumentList] = useState([]);
 
+  const isContractMethod =
+    currentMethod === ETH_CALL || currentMethod === TRACE_CALL;
+
   const updateURL = (val, index) => {
     let argsList = formArgs.split('/').slice(0, formInputs.length); // Remove dangling arguments
     argsList[index] = val;
@@ -47,7 +51,7 @@ const MethodCallContainer = () => {
   };
 
   const onUpdateArguments = async (val, index) => {
-    if (currentMethod === CONTRACT_FUNCTION_METHOD && index === 1) {
+    if (isContractMethod && index === 1) {
       // Prevent updating URL if ABI error
       const { error } = await fetchOrParseAbi(val);
       if (error)
@@ -68,8 +72,7 @@ const MethodCallContainer = () => {
     const [provider, proto] = buildProvider(web3Lib, atob(web3URL));
     let args = argumentList.slice();
     // Pre-flight conversion for contract calls
-    if (currentMethod === CONTRACT_FUNCTION_METHOD)
-      args = getContractFriendlyArguments(args, abi);
+    if (isContractMethod) args = getContractFriendlyArguments(args, abi);
     exec(provider, proto, ...args)
       .then((response) => {
         logItem({
@@ -87,7 +90,7 @@ const MethodCallContainer = () => {
 
   const loadURL = async () => {
     const list = formArgs.split('/');
-    if (currentMethod === CONTRACT_FUNCTION_METHOD && list[1]) {
+    if (isContractMethod && list[1]) {
       // Load ABI
       try {
         list[1] = atob(list[1]);

--- a/src/containers/methodCallContainer.js
+++ b/src/containers/methodCallContainer.js
@@ -42,6 +42,7 @@ const MethodCallContainer = () => {
   const isContractMethod =
     currentMethod === ETH_CALL || currentMethod === TRACE_CALL;
   const argOffset = currentMethod === TRACE_CALL ? TRACE_ARGS_OFFSET : 0;
+  const isWriteAllowed = argOffset > 0
 
   const updateURL = (val, index) => {
     let argsList = formArgs.split('/').slice(0, formInputs.length); // Remove dangling arguments
@@ -56,7 +57,7 @@ const MethodCallContainer = () => {
   const onUpdateArguments = async (val, index) => {
     if (isContractMethod && index === 1 + argOffset) {
       // Prevent updating URL if ABI error
-      const { error } = await fetchOrParseAbi(val);
+      const { error } = await fetchOrParseAbi(val, isWriteAllowed);
       if (error)
         return logItem({
           method: 'error',
@@ -98,7 +99,7 @@ const MethodCallContainer = () => {
       // Load ABI
       try {
         list[1 + argOffset] = atob(list[1 + argOffset]);
-        const { error, abi } = await fetchOrParseAbi(list[1 + argOffset]);
+        const { error, abi } = await fetchOrParseAbi(list[1 + argOffset], isWriteAllowed);
         if (error)
           return logItem({
             method: 'error',

--- a/src/containers/methodCallContainer.js
+++ b/src/containers/methodCallContainer.js
@@ -41,7 +41,7 @@ const MethodCallContainer = () => {
   // Logic when using contract method (eth_call, trace_call)
   const isContractMethod =
     currentMethod === ETH_CALL || currentMethod === TRACE_CALL;
-  const argOffset = currentMethod === TRACE_CALL ? 2 : 0;
+  const argOffset = currentMethod === TRACE_CALL ? TRACE_ARGS_OFFSET : 0;
 
   const updateURL = (val, index) => {
     let argsList = formArgs.split('/').slice(0, formInputs.length); // Remove dangling arguments

--- a/src/containers/methodCallContainer.js
+++ b/src/containers/methodCallContainer.js
@@ -14,7 +14,7 @@ import { navigate, useParams } from '@reach/router';
 
 const ETH_CALL = 'eth_call';
 const TRACE_CALL = 'trace_call';
-const TRACE_ARGS_OFFSET = 2;
+const TRACE_ARGS_OFFSET = 4;
 
 const MethodCallContainer = () => {
   const params = useParams();

--- a/src/containers/methodCallContainer.js
+++ b/src/containers/methodCallContainer.js
@@ -39,10 +39,9 @@ const MethodCallContainer = () => {
   const [argumentList, setArgumentList] = useState([]);
 
   // Logic when using contract method (eth_call, trace_call)
-  const isContractMethod =
-    currentMethod === ETH_CALL || currentMethod === TRACE_CALL;
+  const isContractMethod = [ETH_CALL, TRACE_CALL].includes(currentMethod);
   const argOffset = currentMethod === TRACE_CALL ? TRACE_ARGS_OFFSET : 0;
-  const isWriteAllowed = argOffset > 0
+  const isWriteAllowed = argOffset > 0;
 
   const updateURL = (val, index) => {
     let argsList = formArgs.split('/').slice(0, formInputs.length); // Remove dangling arguments
@@ -99,7 +98,10 @@ const MethodCallContainer = () => {
       // Load ABI
       try {
         list[1 + argOffset] = atob(list[1 + argOffset]);
-        const { error, abi } = await fetchOrParseAbi(list[1 + argOffset], isWriteAllowed);
+        const { error, abi } = await fetchOrParseAbi(
+          list[1 + argOffset],
+          isWriteAllowed
+        );
         if (error)
           return logItem({
             method: 'error',

--- a/src/helpers/contracts.js
+++ b/src/helpers/contracts.js
@@ -142,19 +142,27 @@ export const getContractFriendlyArguments = (argumentList, abi, argOffset) => {
   return traceArgs.concat(args); // add back trace arguments
 };
 
-export const getCodeSampleFriendlyArguments = (argumentList, abi) => {
+export const getCodeSampleFriendlyArguments = (
+  argumentList,
+  abi,
+  argOffset
+) => {
+  let list = argumentList;
+  const traceArgs = list.splice(0, argOffset); // remove trace arguments (if any)
   const [
     contract,
     cleanAbi,
     methodId,
     ...methodSpecificArgs
-  ] = getContractFriendlyArguments(argumentList, abi);
-  return [
+  ] = getContractFriendlyArguments(list, abi);
+  let codeFriendlyArguments = [
     contract,
     cleanAbi,
     methodId,
     JSON.stringify(methodSpecificArgs).replace(/^\[/, '').replace(/\]$/, ''),
   ];
+  if (traceArgs) codeFriendlyArguments.splice(0, 0, ...traceArgs);
+  return codeFriendlyArguments;
 };
 
 export const getFormInputsFromMethod = (

--- a/src/helpers/libs/ethers.js
+++ b/src/helpers/libs/ethers.js
@@ -38,7 +38,6 @@ const contractTemplate = (url, args) => {
   `;
 };
 
-// TODO: fix string/number types for block & trasceType
 const contractTraceTemplate = (url, args) => {
   const [
     traceTypeList,
@@ -60,10 +59,10 @@ const contractTraceTemplate = (url, args) => {
   const iface = new ethers.utils.Interface(abi);
   const data = iface.encodeFunctionData("${method}"${
     methodArgumentsString ? ` , [${methodArgumentsString}]` : ''
-  }); ${from ? `\nconst from = ${from};` : ''}
-  const to = "${contract}"; ${value ? `\nconst value = ${value};` : ''}
-  const transaction = { ${from ? `\nfrom,` : ''}
-    to,
+  }); ${from ? `\n  const from = "${from}";` : ''}
+  const to = "${contract}"; ${value ? `\n  const value = "${value}";` : ''}
+  const transaction = { ${from ? `\n    from,` : ''}
+    to,${value ? `\n    value,` : ''}
     data,
   };
   const response = await provider.send('trace_call', [transaction, ${traceTypeList}, ${block}]);
@@ -1112,11 +1111,10 @@ const filter = {
     },
     codeSample: (url, ...args) => {
       const [traceType, block, ...rest] = args;
-      let traceTypeList = JSON.stringify(traceType.split(', '));
       return contractTraceTemplate(url, [
-        traceTypeList,
+        JSON.stringify(traceType.split(', ')),
         JSON.stringify(block),
-        rest,
+        ...rest,
       ]);
     },
     args: [

--- a/src/helpers/libs/ethers.js
+++ b/src/helpers/libs/ethers.js
@@ -29,7 +29,7 @@ const contractTemplate = (url, args) => {
 
 // HTTP version
 (async () => {
-  const abi = ${abi}
+  const abi = ${abi && JSON.stringify(abi)}
   const provider = new ethers.providers.JsonRpcProvider('${url}');
   const contract = new ethers.Contract('${address}', abi, provider);
   const response = await contract.functions.${method}(${methodArgumentsString});
@@ -54,7 +54,7 @@ const contractTraceTemplate = (url, args) => {
 
 // HTTP version
 (async () => {
-  const abi = ${abi}
+  const abi = ${abi && JSON.stringify(abi)}
   const provider = new ethers.providers.JsonRpcProvider('${url}');
   const iface = new ethers.utils.Interface(abi);
   const data = iface.encodeFunctionData("${method}"${

--- a/src/helpers/libs/ethers.js
+++ b/src/helpers/libs/ethers.js
@@ -1065,8 +1065,18 @@ const filter = {
       return contractTemplate(url, args);
     },
     args: [
-      // TODO: add inputs for Array - Type of trace, one or more of: "vmTrace", "trace", "stateDiff".
-      // Quantity or Tag - (optional) Integer of a block number, or the string 'earliest', 'latest' or 'pending'.
+      {
+        type: 'textfield',
+        description:
+          'Type of trace, one or more of: `vmTrace`, `trace`, `stateDiff`',
+        placeholder: 'i.e. vmTrace, trace',
+      },
+      {
+        type: 'textfield',
+        description:
+          'Hex block number, or the string "latest", "earliest" or "pending"',
+        placeholder: 'i.e. latest or pending',
+      },
       {
         type: 'textarea',
         description: 'Address of contract',

--- a/src/helpers/libs/ethers.js
+++ b/src/helpers/libs/ethers.js
@@ -38,8 +38,18 @@ const contractTemplate = (url, args) => {
   `;
 };
 
+// TODO: fix string/number types for block & trasceType
 const contractTraceTemplate = (url, args) => {
-  const [address, abi, method, methodArgumentsString] = args;
+  const [
+    traceType,
+    block,
+    from,
+    value,
+    contract,
+    abi,
+    method,
+    methodArgumentsString,
+  ] = args;
   return `const ethers = require("ethers");
 // OR import ethers from 'ethers';
 
@@ -47,8 +57,16 @@ const contractTraceTemplate = (url, args) => {
 (async () => {
   const abi = ${abi}
   const provider = new ethers.providers.JsonRpcProvider('${url}');
-  const contract = new ethers.Contract('${address}', abi, provider);
-  const response = await contract.functions.${method}(${methodArgumentsString});
+  const iface = new ethers.utils.Interface(abi);
+  const data = iface.encodeFunctionData("${method}"${
+    methodArgumentsString ? ` , [${methodArgumentsString}]` : ''
+  }); ${from ? `\nconst from = ${from};` : ''}
+  const to = "${contract}"; ${value ? `\nconst value = ${value};` : ''}
+  const transaction = { ${from ? `\nfrom,` : ''}
+    to,
+    data,
+  };
+  const response = await provider.send('trace_call', [transaction, [${traceType}], ${block}]);
   console.log(response);
 })()
   `;
@@ -1090,7 +1108,7 @@ const filter = {
     },
     codeSample: (url, ...args) => {
       // TODO: change template
-      return contractTemplate(url, args);
+      return contractTraceTemplate(url, args);
     },
     args: [
       {

--- a/src/helpers/libs/ethers.js
+++ b/src/helpers/libs/ethers.js
@@ -41,7 +41,7 @@ const contractTemplate = (url, args) => {
 // TODO: fix string/number types for block & trasceType
 const contractTraceTemplate = (url, args) => {
   const [
-    traceType,
+    traceTypeList,
     block,
     from,
     value,
@@ -66,7 +66,7 @@ const contractTraceTemplate = (url, args) => {
     to,
     data,
   };
-  const response = await provider.send('trace_call', [transaction, [${traceType}], ${block}]);
+  const response = await provider.send('trace_call', [transaction, ${traceTypeList}, ${block}]);
   console.log(response);
 })()
   `;
@@ -1104,11 +1104,20 @@ const filter = {
         value,
         data,
       };
-      return provider.send('trace_call', [transaction, [traceType], block]);
+      return provider.send('trace_call', [
+        transaction,
+        traceType.split(', '),
+        block,
+      ]);
     },
     codeSample: (url, ...args) => {
-      // TODO: change template
-      return contractTraceTemplate(url, args);
+      const [traceType, block, ...rest] = args;
+      let traceTypeList = JSON.stringify(traceType.split(', '));
+      return contractTraceTemplate(url, [
+        traceTypeList,
+        JSON.stringify(block),
+        rest,
+      ]);
     },
     args: [
       {

--- a/src/helpers/libs/ethers.js
+++ b/src/helpers/libs/ethers.js
@@ -1048,6 +1048,42 @@ const filter = {
       },
     ],
   },
+  trace_call: {
+    exec: (provider, proto, ...args) => {
+      const [address, abi, method, ...rest] = args;
+      const contract = new ethers.Contract(address, abi, provider);
+      return contract.functions[method](...rest);
+      // TODO: encode data and parse agruments properly
+      const data = 'no data';
+      const array = 'trace';
+      const quantity = null;
+      // return provider.send('trace_call', data, array, quantity);
+      return () => console.log('trace_call:', data);
+    },
+    codeSample: (url, ...args) => {
+      // TODO: change template
+      return contractTemplate(url, args);
+    },
+    args: [
+      // TODO: add inputs for Array - Type of trace, one or more of: "vmTrace", "trace", "stateDiff".
+      // Quantity or Tag - (optional) Integer of a block number, or the string 'earliest', 'latest' or 'pending'.
+      {
+        type: 'textarea',
+        description: 'Address of contract',
+        placeholder: 'i.e. 0x91b51c173a4...',
+      },
+      {
+        type: 'textarea',
+        description: 'Contract ABI (URL or single function object)',
+        placeholder:
+          'i.e. [{"inputs":[{"name":"chainId...\nOR\nhttps://raw.githubusercontent.com/.../build/contracts/ERC20.json',
+      },
+      {
+        type: 'dropdown',
+        description: 'Function name (READ only)',
+      },
+    ],
+  },
 };
 
 export default EthersCalls;

--- a/src/helpers/libs/web3js.js
+++ b/src/helpers/libs/web3js.js
@@ -67,14 +67,16 @@ const contractTraceTemplate = (url, args) => {
     method,
     methodArgumentsString,
   ] = args;
-  return `const ethers = require("ethers");
-// OR import ethers from 'ethers';
+  return `const Web3 = require("web3");
+// OR import Web3 from 'web3';
 
 // HTTP version
 (async () => {
   const abi = ${abi}
   const web3 = new Web3('${url}');
-  const data = provider.eth.abi.encodeFunctionSignature(${method}(${methodArgumentsString}));
+  const data = web3.eth.abi.encodeFunctionSignature("${method}(${methodArgumentsString})"); ${
+    from ? `\n  const from = "${from}";` : ''
+  }
   const to = "${contract}"; ${value ? `\n  const value = "${value}";` : ''}
   const transaction = { ${from ? `\n    from,` : ''}
     to,${value ? `\n    value,` : ''}
@@ -90,9 +92,9 @@ const contractTraceTemplate = (url, args) => {
       },
     ],
   });
-  const response = await web3.parityTraceCall(data, ${traceTypeList}, ${block});
+  const response = await web3.parityTraceCall(transaction, ${traceTypeList}, ${block});
   console.log(response);
-  `;
+})()`;
 };
 
 const Web3JSCalls = {
@@ -1165,6 +1167,7 @@ const Web3JSCalls = {
           },
         ],
       });
+      console.log(transaction);
       return provider.parityTraceCall(
         transaction,
         traceType.split(', '),

--- a/src/helpers/libs/web3js.js
+++ b/src/helpers/libs/web3js.js
@@ -74,8 +74,7 @@ const contractTraceTemplate = (url, args) => {
 (async () => {
   const abiFragment = ${abi && JSON.stringify(abi[0])}
   const web3 = new Web3('${url}');
-  const data = provider.eth.abi.encodeFunctionCall(abiFragment, rest);
-  const data = web3.eth.abi.encodeFunctionSignature("${method}(${methodArgumentsString})"); ${
+  const data = web3.eth.abi.encodeFunctionCall(abiFragment, [${methodArgumentsString}]);${
     from ? `\n  const from = "${from}";` : ''
   }
   const to = "${contract}"; ${value ? `\n  const value = "${value}";` : ''}

--- a/src/helpers/libs/web3js.js
+++ b/src/helpers/libs/web3js.js
@@ -48,7 +48,7 @@ const contractTemplate = (url, args) => {
 
 // HTTP version
 (async () => {
-  const abi = ${abi}
+  const abi = ${abi && JSON.stringify(abi)}
   const web3 = new Web3('${url}');
   const contract = new web3.eth.Contract(abi, '${address}');
   const response = await contract.methods.${method}(${methodArgumentsString});
@@ -72,8 +72,9 @@ const contractTraceTemplate = (url, args) => {
 
 // HTTP version
 (async () => {
-  const abi = ${abi}
+  const abiFragment = ${abi && JSON.stringify(abi[0])}
   const web3 = new Web3('${url}');
+  const data = provider.eth.abi.encodeFunctionCall(abiFragment, rest);
   const data = web3.eth.abi.encodeFunctionSignature("${method}(${methodArgumentsString})"); ${
     from ? `\n  const from = "${from}";` : ''
   }
@@ -1146,8 +1147,9 @@ const Web3JSCalls = {
         method,
         ...rest
       ] = args;
-      const data = provider.eth.abi.encodeFunctionSignature(
-        `${method}(${rest})`
+      const data = provider.eth.abi.encodeFunctionCall(
+        JSON.parse(abi)[0],
+        rest
       );
       if (value === '') value = null;
       if (from === '') from = null;
@@ -1167,7 +1169,6 @@ const Web3JSCalls = {
           },
         ],
       });
-      console.log(transaction);
       return provider.parityTraceCall(
         transaction,
         traceType.split(', '),

--- a/src/helpers/web3Config.js
+++ b/src/helpers/web3Config.js
@@ -300,6 +300,12 @@ const Web3RpcCalls = {
     web3: calls.web3.default.trace_filter,
     ethers: calls.ethers.default.trace_filter,
   },
+  trace_call: {
+    description:
+      'Executes the given call and returns a number of possible traces for it.',
+    web3: calls.web3.default.trace_call,
+    ethers: calls.ethers.default.trace_call,
+  },
 };
 
 export default Web3RpcCalls;


### PR DESCRIPTION
`trace_call` is working now for ethers.js

![image](https://user-images.githubusercontent.com/35622595/95547246-7d99a180-09d0-11eb-8a1c-b1e9ea631ba0.png)

TODO:

- [x] Add trace_call for web3 library

- [x] Update code samples

- [x] Add flag to not filter WRITE transactions (we can use them for trace)