### PR TITLE
Add newFilter, newBlockFilter, newPendingTransactionFilter

### DIFF
--- a/src/containers/methodCallContainer.js
+++ b/src/containers/methodCallContainer.js
@@ -131,7 +131,7 @@ const MethodCallContainer = () => {
   useEffect(() => {
     if (!argumentList) return;
     const methodId = argumentList[2 + argOffset];
-    if (!methodId || !abi) return; //setFormInputs(formInputs);
+    if (!methodId || !abi) return;
     setFormInputs(
       getFormInputsFromMethod(abi, methodId, formInputs, argOffset)
     );

--- a/src/containers/methodCallContainer.js
+++ b/src/containers/methodCallContainer.js
@@ -127,6 +127,7 @@ const MethodCallContainer = () => {
     if (newUrl) updateURL(newUrl, 2 + argOffset);
   }, [abi, formInputs]);
 
+  // Update on contract method call change
   useEffect(() => {
     if (!argumentList) return;
     setFormInputs(

--- a/src/containers/methodCallContainer.js
+++ b/src/containers/methodCallContainer.js
@@ -127,16 +127,13 @@ const MethodCallContainer = () => {
     if (newUrl) updateURL(newUrl, 2 + argOffset);
   }, [abi, formInputs]);
 
-  // Update on contract method call change
+  // Update the form inputs whenever a new contract method is selected
   useEffect(() => {
     if (!argumentList) return;
+    const methodId = argumentList[2 + argOffset];
+    if (!methodId || !abi) return; //setFormInputs(formInputs);
     setFormInputs(
-      getFormInputsFromMethod(
-        abi,
-        argumentList[2 + argOffset],
-        formInputs,
-        argOffset
-      )
+      getFormInputsFromMethod(abi, methodId, formInputs, argOffset)
     );
   }, [argumentList[2 + argOffset]]);
 

--- a/src/containers/statusBarContainer.js
+++ b/src/containers/statusBarContainer.js
@@ -8,7 +8,13 @@ const StatusBarContainer = () => {
   const web3URL = params.web3URL || '';
   const [statusInfo, setStatusInfo] = useState({});
   useEffect(() => {
-    web3State(atob(web3URL)).then(setStatusInfo);
+    let isMounted = true;
+    web3State(atob(web3URL)).then((data) => {
+      if (isMounted) setStatusInfo(data);
+    });
+    return () => {
+      isMounted = false;
+    };
   }, [web3URL]);
 
   return <StatusBar {...statusInfo} />;

--- a/src/helpers/contracts.js
+++ b/src/helpers/contracts.js
@@ -177,7 +177,6 @@ export const getFormInputsFromMethod = (
   formInputs,
   argOffset
 ) => {
-  if (!methodId || !abi) return formInputs;
   const newFormInputs = getArgumentsFromMethodId(abi, methodId);
   if (newFormInputs)
     return [

--- a/src/helpers/contracts.js
+++ b/src/helpers/contracts.js
@@ -177,7 +177,7 @@ export const getFormInputsFromMethod = (
   formInputs,
   argOffset
 ) => {
-  if (!methodId) return formInputs;
+  if (!methodId || !abi) return formInputs;
   const newFormInputs = getArgumentsFromMethodId(abi, methodId);
   if (newFormInputs)
     return [

--- a/src/helpers/contracts.js
+++ b/src/helpers/contracts.js
@@ -177,7 +177,7 @@ export const getFormInputsFromMethod = (
   formInputs,
   argOffset
 ) => {
-  if (!methodId) return;
+  if (!methodId) return formInputs;
   const newFormInputs = getArgumentsFromMethodId(abi, methodId);
   if (newFormInputs)
     return [

--- a/src/helpers/libs/ethers.js
+++ b/src/helpers/libs/ethers.js
@@ -105,7 +105,7 @@ const filter = {
 `;
 };
 
-const filterTemplate = (url, filterMethod, ...args) => {
+const filterTemplate = (url, filterMethod) => {
   return `const ethers = require("ethers");
 // OR import ethers from 'ethers';
 
@@ -827,7 +827,7 @@ const EthersCalls = {
       const filter = await provider.send('eth_newPendingTransactionFilter');
       return provider.getLogs(filter);
     },
-    codeSample: (url, ...args) => {
+    codeSample: (url) => {
       return filterTemplate(url, 'eth_newPendingTransactionFilter');
     },
     args: [],

--- a/src/helpers/libs/ethers.js
+++ b/src/helpers/libs/ethers.js
@@ -105,6 +105,28 @@ const filter = {
 `;
 };
 
+const filterTemplate = (url, filterMethod, ...args) => {
+  return `const ethers = require("ethers");
+// OR import ethers from 'ethers';
+
+// HTTP version
+(async () => {
+  const provider = new ethers.providers.JsonRpcProvider('${url}');
+  const filterId = await provider.send('${filterMethod}')
+  const logs = await provider.getLogs(filterId);
+  console.log(logs);
+})()
+
+// WebSocket version
+(async () => {
+  const provider = new ethers.providers.WebSocketProvider('${url}');
+  const filterId = await provider.send('${filterMethod}')
+  const logs = await provider.getLogs(filterId);
+  console.log(logs);
+})()
+`;
+};
+
 const EthersCalls = {
   web3_clientVersion: {
     exec: (provider, proto, ...args) => {
@@ -806,11 +828,7 @@ const EthersCalls = {
       return provider.getLogs(filter);
     },
     codeSample: (url, ...args) => {
-      return ethersTemplate(
-        "send('eth_newPendingTransactionFilter')",
-        'filter',
-        url
-      );
+      return filterTemplate(url, 'eth_newPendingTransactionFilter');
     },
     args: [],
   },

--- a/src/helpers/libs/ethers.js
+++ b/src/helpers/libs/ethers.js
@@ -9,7 +9,7 @@ const ethersTemplate = (methodCall, varName, url) => {
   const provider = new ethers.providers.JsonRpcProvider('${url}');
   const ${varName} = await provider.${methodCall};
   console.log(${varName});
-})()
+})();
 
 
 // WebSocket version
@@ -17,7 +17,7 @@ const ethersTemplate = (methodCall, varName, url) => {
   const provider = new ethers.providers.WebSocketProvider('${url}');
   const ${varName} = await provider.${methodCall};
   console.log(${varName});
-})()
+})();
 `;
 };
 
@@ -67,7 +67,7 @@ const contractTraceTemplate = (url, args) => {
   };
   const response = await provider.send('trace_call', [transaction, ${traceTypeList}, ${block}]);
   console.log(response);
-})()
+})();
   `;
 };
 
@@ -81,17 +81,21 @@ ${filter ? `\n${filter}\n` : ''}
   const filterId = await provider.send('${filterMethod}'${
     filter ? ', [filter]' : ''
   })
+  console.log(filterId);
   const logs = await provider.send('eth_getFilterChanges', [filterId]);
   console.log(logs);
-})()
+})();
 
 // WebSocket version
 (async () => {
   const provider = new ethers.providers.WebSocketProvider('${url}');
-  const filterId = await provider.send('${filterMethod}')
+  const filterId = await provider.send('${filterMethod}'${
+    filter ? ', [filter]' : ''
+  })
+  console.log(filterId);
   const logs = await provider.send('eth_getFilterChanges', [filterId]);
   console.log(logs);
-})()
+})();
 `;
 };
 

--- a/src/helpers/libs/ethers.js
+++ b/src/helpers/libs/ethers.js
@@ -755,8 +755,9 @@ const EthersCalls = {
     codeSample: (url, ...args) => {
       const filter = `const filter = {
   ${args[0] ? "fromBlock: '" + args[0] + "'" : "fromBlock: 'latest'"},
-  ${args[1] ? "toBlock: '" + args[1] + "'" : "toBlock: 'latest'"},
-  ${args[2] ? "address: '" + args[2] + "'" : ''},
+  ${args[1] ? "toBlock: '" + args[1] + "'" : "toBlock: 'latest'"},${
+        args[2] ? "\n  address: '" + args[2] + "'," : ''
+      }
   topics: ${
     args[3]
       ? JSON.stringify(

--- a/src/helpers/libs/web3js.js
+++ b/src/helpers/libs/web3js.js
@@ -97,6 +97,11 @@ const contractTraceTemplate = (url, args) => {
 })()`;
 };
 
+const newFilterTemplate = (url, args) => {
+  // TODO
+  return ``;
+};
+
 const Web3JSCalls = {
   web3_clientVersion: {
     exec: (provider, proto, ...args) => {
@@ -719,14 +724,55 @@ const Web3JSCalls = {
   },
   eth_newFilter: {
     exec: (provider, proto, ...args) => {
-      return new Promise((resolve, reject) =>
-        reject('EtherFlow does not YET support this method.')
-      );
+      const filter = {};
+      filter.topics = args[3]
+        ? args[3].split(',').map((x) => (x === 'null' ? null : x.split('||')))
+        : [];
+      filter.fromBlock = args[0] ? args[0] : 'latest';
+      filter.toBlock = args[1] ? args[1] : 'latest';
+      filter.address = args[2] ? args[2] : null;
+
+      provider.extend({
+        methods: [
+          {
+            name: 'parityNewFilter',
+            call: 'eth_newFilter',
+            params: 1,
+            inputFormatter: [null],
+          },
+        ],
+      });
+      return provider.parityNewFilter(filter);
     },
     codeSample: (url, ...args) => {
-      return '/* Not Supported by EtherFlow yet */';
+      return newFilterTemplate(url, args);
     },
-    args: [],
+    args: [
+      {
+        type: 'textfield',
+        description:
+          'fromBlock: Hex block number, or the string "latest", "earliest" or "pending"',
+        placeholder: 'i.e. 0x29c',
+      },
+      {
+        type: 'textfield',
+        description:
+          'toBlock: Hex block number, or the string "latest", "earliest" or "pending"',
+        placeholder: 'i.e. 0x29c',
+      },
+      {
+        type: 'textarea',
+        description:
+          'address: (optional) Contract address or a list of addresses from which logs should originate.',
+        placeholder: 'i.e. 0x19624ffa41fe26744e74fdbba77bef967a222d4c',
+      },
+      {
+        type: 'textarea',
+        description:
+          'topics: (optional) Comma separated strings with filter topics, for "or" functionality use ||. Topics are order-dependent.',
+        placeholder: 'i.e. 0x1962||0x16c4,null',
+      },
+    ],
   },
   eth_newBlockFilter: {
     exec: (provider, proto, ...args) => {

--- a/src/helpers/libs/web3js.js
+++ b/src/helpers/libs/web3js.js
@@ -731,7 +731,6 @@ const Web3JSCalls = {
       filter.fromBlock = args[0] ? args[0] : 'latest';
       filter.toBlock = args[1] ? args[1] : 'latest';
       filter.address = args[2] ? args[2] : null;
-
       provider.extend({
         methods: [
           {

--- a/src/helpers/libs/web3js.js
+++ b/src/helpers/libs/web3js.js
@@ -741,7 +741,7 @@ const Web3JSCalls = {
           },
         ],
       });
-      return provider.parityNewFilter(filter);
+      return provider.eth.getPastLogs(filter);
     },
     codeSample: (url, ...args) => {
       return newFilterTemplate(url, args);

--- a/src/helpers/libs/web3js.js
+++ b/src/helpers/libs/web3js.js
@@ -794,12 +794,19 @@ const Web3JSCalls = {
     args: [],
   },
   eth_newPendingTransactionFilter: {
-    exec: (provider, proto, ...args) => {
-      return new Promise((resolve, reject) =>
-        provider.eth.subscribe('pendingTransactions', (error, result) => {
-          if (!error) resolve(result);
-        })
-      );
+    exec: (provider, proto) => {
+      provider.extend({
+        methods: [
+          {
+            name: 'newPendingTransactionFilter',
+            call: 'eth_newPendingTransactionFilter',
+            params: 0,
+            inputFormatter: [],
+          },
+        ],
+      });
+      const filter = provider.newPendingTransactionFilter();
+      return provider;
     },
     codeSample: (url, ...args) => {
       return `const Web3 = require("web3");

--- a/src/helpers/libs/web3js.js
+++ b/src/helpers/libs/web3js.js
@@ -831,26 +831,24 @@ const Web3JSCalls = {
   },
   eth_newBlockFilter: {
     exec: (provider, proto, ...args) => {
-      return new Promise((resolve, reject) =>
-        provider.eth.subscribe('newBlockHeaders', (error, result) => {
-          if (!error) resolve(result);
-        })
-      );
+      provider.extend({
+        methods: [
+          {
+            name: 'eth_newBlockFilter',
+            call: 'eth_newBlockFilter',
+            params: 0,
+            inputFormatter: [],
+          },
+        ],
+      });
+      const filterId = provider.eth_newBlockFilter();
+      return provider.eth.getPastLogs(filterId);
     },
-    codeSample: (url, ...args) => {
-      return `const Web3 = require("web3");
-// OR Web3 ethers from 'web3';
-
-// HTTP version
-(async () => {
-  const web3 = new Web3('${url}');
-  web3.eth.subscribe('newBlockHeaders', console.log);
-})()`;
-    },
+    codeSample: (url, ...args) => filterTemplate(url, 'eth_newBlockFilter'),
     args: [],
   },
   eth_newPendingTransactionFilter: {
-    exec: async (provider, proto) => {
+    exec: (provider, proto) => {
       provider.extend({
         methods: [
           {

--- a/src/helpers/libs/web3js.js
+++ b/src/helpers/libs/web3js.js
@@ -102,6 +102,29 @@ const newFilterTemplate = (url, args) => {
   return ``;
 };
 
+const filterTemplate = (url, filterMethod) => {
+  return `const Web3 = require("web3");
+// OR import Web3 from 'web3';
+
+// HTTP version
+(async () => {
+  const web3 = new Web3('${url}');
+  web3.extend({
+    methods: [
+      {
+        name: '${filterMethod}',
+        call: '${filterMethod}',
+        params: 0,
+        inputFormatter: [],
+      },
+    ],
+  });
+  const filterId = web3.${filterMethod}();
+  const response = await web3.eth.getPastLogs(filterId);
+  console.log(response);
+})()`;
+};
+
 const Web3JSCalls = {
   web3_clientVersion: {
     exec: (provider, proto, ...args) => {
@@ -794,30 +817,21 @@ const Web3JSCalls = {
     args: [],
   },
   eth_newPendingTransactionFilter: {
-    exec: (provider, proto) => {
+    exec: async (provider, proto) => {
       provider.extend({
         methods: [
           {
-            name: 'newPendingTransactionFilter',
+            name: 'eth_newPendingTransactionFilter',
             call: 'eth_newPendingTransactionFilter',
             params: 0,
             inputFormatter: [],
           },
         ],
       });
-      const filter = provider.newPendingTransactionFilter();
-      return provider;
+      const filterId = provider.eth_newPendingTransactionFilter();
+      return provider.eth.getPastLogs(filterId);
     },
-    codeSample: (url, ...args) => {
-      return `const Web3 = require("web3");
-// OR Web3 ethers from 'web3';
-
-// HTTP version
-(async () => {
-  const web3 = new Web3('${url}');
-  web3.eth.subscribe('pendingTransactions', console.log);
-})()`;
-    },
+    codeSample: (url) => filterTemplate(url, 'eth_newPendingTransactionFilter'),
     args: [],
   },
   eth_uninstallFilter: {

--- a/src/helpers/libs/web3js.js
+++ b/src/helpers/libs/web3js.js
@@ -786,8 +786,9 @@ const Web3JSCalls = {
     codeSample: (url, ...args) => {
       const filter = `const filter = {
   ${args[0] ? "fromBlock: '" + args[0] + "'" : "fromBlock: 'latest'"},
-  ${args[1] ? "toBlock: '" + args[1] + "'" : "toBlock: 'latest'"},
-  ${args[2] ? "address: '" + args[2] + "'" : ''},
+  ${args[1] ? "toBlock: '" + args[1] + "'" : "toBlock: 'latest'"},${
+        args[2] ? "\n  address: '" + args[2] + "'," : ''
+      }
   topics: ${
     args[3]
       ? JSON.stringify(

--- a/src/helpers/web3Config.js
+++ b/src/helpers/web3Config.js
@@ -211,19 +211,19 @@ const Web3RpcCalls = {
   },
   eth_newFilter: {
     description:
-      'Creates a filter object, based on filter options, to notify when the state changes (logs). The resulting value from the filter is immediately returned.',
+      'Creates a filter object, based on filter options, to notify when the state changes (logs).  The resulting value from the filter is immediately returned using `eth_getFilterChanges`.',
     web3: calls.web3.default.eth_newFilter,
     ethers: calls.ethers.default.eth_newFilter,
   },
   eth_newBlockFilter: {
     description:
-      'Creates a filter in the node, to notify when a new block arrives. To check if the state has changed, call `eth_getFilterChanges`.',
+      'Creates a filter in the node, to notify when a new block arrives. The resulting value from the filter is immediately returned using `eth_getFilterChanges`.',
     web3: calls.web3.default.eth_newBlockFilter,
     ethers: calls.ethers.default.eth_newBlockFilter,
   },
   eth_newPendingTransactionFilter: {
     description:
-      'Creates a filter in the node, to notify when new pending transactions arrive. The resulting value from the filter is immediately returned.',
+      'Creates a filter in the node, to notify when new pending transactions arrive. The resulting value from the filter is immediately returned using `eth_getFilterChanges`.',
     web3: calls.web3.default.eth_newPendingTransactionFilter,
     ethers: calls.ethers.default.eth_newPendingTransactionFilter,
   },

--- a/src/helpers/web3Config.js
+++ b/src/helpers/web3Config.js
@@ -211,7 +211,7 @@ const Web3RpcCalls = {
   },
   eth_newFilter: {
     description:
-      'Creates a filter object, based on filter options, to notify when the state changes (logs). To check if the state has changed, call eth_getFilterChanges.',
+      'Creates a filter object, based on filter options, to notify when the state changes (logs). The resulting value from the filter is immediately returned.',
     web3: calls.web3.default.eth_newFilter,
     ethers: calls.ethers.default.eth_newFilter,
   },
@@ -223,7 +223,7 @@ const Web3RpcCalls = {
   },
   eth_newPendingTransactionFilter: {
     description:
-      'Creates a filter in the node, to notify when new pending transactions arrive. To check if the state has changed, call eth_getFilterChanges.',
+      'Creates a filter in the node, to notify when new pending transactions arrive. The resulting value from the filter is immediately returned.',
     web3: calls.web3.default.eth_newPendingTransactionFilter,
     ethers: calls.ethers.default.eth_newPendingTransactionFilter,
   },


### PR DESCRIPTION
- Remove user suggestions to use `eth_getFilterChanges`.

Update methods for ethers.js + web3.js to generate the `filterId` and return `eth_getFilterChanges(filterId)`, and added code samples:

- `eth_newFilter`
- `eth_newBlockFilter`
- `eth_newPendingTransactionFilter`
